### PR TITLE
Fix duplicate listener bug in toast hook

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent multiple listeners in `useToast` hook

## Testing
- `npm run check` *(fails: various schema TS2344 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a315d59f8832489bbc681fd69c275