### PR TITLE
Fix toast auto-dismiss timing

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -6,7 +6,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 10000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- reduce `TOAST_REMOVE_DELAY` to 10 seconds so toasts are removed automatically

## Testing
- `npm run check` *(fails: TS2344 errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a350141088324b2ff0eeb63ab41cd