### PR TITLE
Apply homepage background to all pages

### DIFF
--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -37,7 +37,7 @@ export default function About() {
   ];
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-background text-foreground">
       {/* Hero Section */}
       <section className="relative py-20 bg-gradient-to-br from-black via-dark-navy to-almost-black">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -108,7 +108,7 @@ export default function Admin() {
   };
 
   if (!user) {
-    return <div className="min-h-screen bg-black flex items-center justify-center">
+    return <div className="min-h-screen bg-background flex items-center justify-center text-foreground">
       <div className="text-white">Loading...</div>
     </div>;
   }
@@ -118,7 +118,7 @@ export default function Admin() {
   );
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-background text-foreground">
       {/* Header */}
       <header className="bg-almost-black border-b border-gray-800 p-4">
         <div className="max-w-7xl mx-auto flex justify-between items-center">

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -37,7 +37,7 @@ export default function CalendarPage() {
   };
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-background text-foreground">
       {/* Header */}
       <header className="bg-almost-black border-b border-gray-800 p-4">
         <div className="max-w-7xl mx-auto">

--- a/client/src/pages/contact.tsx
+++ b/client/src/pages/contact.tsx
@@ -141,7 +141,7 @@ export default function Contact() {
   ];
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-background text-foreground">
       {/* Hero Section */}
       <section className="py-20 bg-gradient-to-br from-black via-dark-navy to-almost-black">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">

--- a/client/src/pages/group-sessions.tsx
+++ b/client/src/pages/group-sessions.tsx
@@ -95,7 +95,7 @@ export default function GroupSessions() {
   ];
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-background text-foreground">
       {/* Hero Section */}
       <section className="relative py-20 bg-gradient-to-br from-black via-dark-navy to-almost-black">
         <div className="absolute inset-0 bg-black bg-opacity-40"></div>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -8,7 +8,7 @@ import { siteContent } from "@shared/content";
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-background text-foreground">
       <HeroSection />
       <ExpectationSection />
       <ServicesSection />

--- a/client/src/pages/individual-coaching.tsx
+++ b/client/src/pages/individual-coaching.tsx
@@ -74,7 +74,7 @@ export default function IndividualCoaching() {
   ];
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-background text-foreground">
       {/* Hero Section */}
       <section className="relative py-20 bg-gradient-to-br from-black via-dark-navy to-almost-black">
         <div className="absolute inset-0 bg-black bg-opacity-40"></div>

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -65,7 +65,7 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen bg-black flex items-center justify-center px-4">
+    <div className="min-h-screen bg-background flex items-center justify-center px-4 text-foreground">
       <Card className="w-full max-w-md bg-almost-black border-gray-800">
         <CardHeader className="text-center">
           <div className="w-16 h-16 bg-lfc-red rounded-full flex items-center justify-center mx-auto mb-4">

--- a/client/src/pages/parent-dashboard.tsx
+++ b/client/src/pages/parent-dashboard.tsx
@@ -80,7 +80,7 @@ export default function ParentDashboard() {
 
   if (!user) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-almost-black flex items-center justify-center">
+      <div className="min-h-screen bg-background flex items-center justify-center text-foreground">
         <div className="animate-spin w-8 h-8 border-4 border-lfc-red border-t-transparent rounded-full"></div>
       </div>
     );
@@ -92,7 +92,7 @@ export default function ParentDashboard() {
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())[0];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-almost-black">
+    <div className="min-h-screen bg-background text-foreground">
       {/* Header */}
       <div className="bg-almost-black border-b border-gray-800">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -82,7 +82,7 @@ export default function Register() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-almost-black flex items-center justify-center p-4">
+    <div className="min-h-screen bg-background flex items-center justify-center p-4 text-foreground">
       <div className="w-full max-w-2xl">
         <div className="text-center mb-8">
           <Link href="/" className="inline-flex items-center text-lfc-red hover:text-bright-red mb-4">


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Unify page backgrounds to use theme-aware utility classes for consistent styling across the site.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Every page-level wrapper now uses `bg-background` and `text-foreground` instead of hard-coded `bg-black` / `text-white` or dark gradients. This ensures pages inherit a consistent white background in light mode (matching the homepage) and the appropriate color in dark mode, as defined by the CSS variables in `index.css`. Existing dark hero/section blocks are unaffected and still render correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-905f6e43-18e5-434f-a235-14771e3b07ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-905f6e43-18e5-434f-a235-14771e3b07ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>