### PR TITLE
Fix images not displaying on website

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "client", "src"),
       "@shared": path.resolve(__dirname, "shared"),
-      "@assets": path.resolve(__dirname, "attached_assets"),
+      "@assets": path.resolve(__dirname, "public", "attached_assets"),
     },
   },
   // root: path.resolve(__dirname, "client"), // <-- REMOVE or COMMENT OUT this line
@@ -23,6 +23,5 @@ export default defineConfig({
         }
       }
     }
-  },
-  publicDir: path.resolve(__dirname, "attached_assets")
+  }
 });


### PR DESCRIPTION
Fix image loading by correcting Vite's public asset path and alias.

Images were not displaying because `vite.config.ts` incorrectly set `publicDir` to `attached_assets`, while the actual image files resided in `public/attached_assets`. This mismatch caused 404 errors for image requests. The `@assets` alias was also updated to reflect the correct path.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea30f29b-f3c0-4530-9306-54775fc701f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea30f29b-f3c0-4530-9306-54775fc701f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>