### PR TITLE
Fix mobile image display issues

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,5 +24,7 @@ export default defineConfig({
       }
     }
   },
-  publicDir: path.resolve(__dirname, "attached_assets")
+  // Serve static assets from the conventional `public` directory so that
+  // images are correctly included in both dev and production builds.
+  publicDir: path.resolve(__dirname, "public")
 });


### PR DESCRIPTION
Correct Vite's `publicDir` to `public` to fix missing images on mobile builds.

Previously, `publicDir` was incorrectly set to `attached_assets`, causing images to not be included in the production bundle and resulting in 404 errors for image assets on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-02e813f4-cbcc-4ba1-834a-a1d1023237c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02e813f4-cbcc-4ba1-834a-a1d1023237c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>