### PR TITLE
Investigate missing images using screenshot

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "client", "src"),
       "@shared": path.resolve(__dirname, "shared"),
-      "@assets": path.resolve(__dirname, "attached_assets"),
+      // Expose the public assets directory to the source code (if ever needed)
+      "@assets": path.resolve(__dirname, "public", "attached_assets"),
     },
   },
   // root: path.resolve(__dirname, "client"), // <-- REMOVE or COMMENT OUT this line
@@ -24,5 +25,6 @@ export default defineConfig({
       }
     }
   },
-  publicDir: path.resolve(__dirname, "attached_assets")
+  // Ensure Vite copies everything from the standard public folder (including `attached_assets`) to the build output
+  publicDir: path.resolve(__dirname, "public")
 });


### PR DESCRIPTION
Fix image display issues by correcting Vite's `publicDir` and `@assets` alias configurations.

The `publicDir` was incorrectly set to a non-existent folder, preventing static assets (like images) from being copied to the production build. The `@assets` alias was also updated to resolve to the correct path within the `public` directory. This ensures images are properly included and accessible after deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-db4635cc-81a5-4d7f-8321-076433b2d03c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db4635cc-81a5-4d7f-8321-076433b2d03c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>